### PR TITLE
update dependency type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-pack (1.0.0)
+      cocoapods (>= 1.10, < 2.0)
       rubyzip (~> 1.1)
 
 GEM
@@ -138,7 +139,6 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.0)
   bundler (~> 2.0)
-  cocoapods (>= 1.10, < 2.0)
   cocoapods-pack!
   pry (~> 0.10)
   rake (~> 13.0)

--- a/cocoapods-pack.gemspec
+++ b/cocoapods-pack.gemspec
@@ -23,12 +23,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.5.0'
-  spec.add_development_dependency 'bundler', '~> 2.0'
 
+  spec.add_runtime_dependency 'cocoapods', '>= 1.10', '< 2.0'
+  spec.add_runtime_dependency 'rubyzip', '~> 1.1'
+
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'activesupport', '~> 5.0'
-  spec.add_development_dependency 'cocoapods', '>= 1.10', '< 2.0'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_dependency 'rubyzip', '~> 1.1'
+
 end


### PR DESCRIPTION
Hello,I think cocoapods should belong to a runtime dependency, not a development dependency.