### PR TITLE
Support local podspec file that download sources from remote.

### DIFF
--- a/lib/cocoapods-pack/command/pack.rb
+++ b/lib/cocoapods-pack/command/pack.rb
@@ -464,6 +464,16 @@ module Pod
                               end
                               @is_local = false
                               output_path
+                            elsif path =~ %r{file?://}
+                              require 'fileutils'
+                              require 'uri'
+                              output_path = podspecs_tmp_dir + File.basename(path)
+                              output_path.dirname.mkpath
+                              uri = URI(path)
+                              absolute_path = File.expand_path(File.join(uri.host, uri.path), Dir.pwd)                             
+                              FileUtils.cp absolute_path, output_path
+                              @is_local = false
+                              output_path
                             elsif Pathname.new(path).directory?
                               raise Informative, "Podspec specified in `#{path}` is a directory."
                             else


### PR DESCRIPTION
I'd like to get a function such as below, any good idea?
for now I implemented it by describing path with `file://`.

```sh
curl https://raw.githubusercontent.com/Alamofire/Alamofire/master/Alamofire.podspec > path/to/local_podspecs/Alamofire.podspec
```

```sh
pod pack file://path/to/local_podspecs/Alamofire.podspec ...
```

The reason why I needed is to create also frameworks that not published libraries.